### PR TITLE
Also block when a parent domain is blocked

### DIFF
--- a/blocklist_test.go
+++ b/blocklist_test.go
@@ -35,6 +35,23 @@ func TestExample(t *testing.T) {
 	assert.Equal(t, dns.RcodeSuccess, rec.Rcode)
 }
 
+func TestAllowedDomain(t *testing.T) {
+	x := Blocklist{Next: NextHandler(), domains: map[string]bool{"bad.domain.": true}}
+
+	b := &bytes.Buffer{}
+	golog.SetOutput(b)
+
+	ctx := context.TODO()
+	r := new(dns.Msg)
+	r.SetQuestion("example.com.", dns.TypeA)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	x.ServeDNS(ctx, rec, r)
+
+	assert.Equal(t, dns.RcodeSuccess, rec.Rcode)
+}
+
 func TestBlockedDomain(t *testing.T) {
 	x := Blocklist{Next: NextHandler(), domains: map[string]bool{"bad.domain.": true}}
 

--- a/blocklist_test.go
+++ b/blocklist_test.go
@@ -86,6 +86,23 @@ func TestBlockedParentDomain(t *testing.T) {
 	assert.Equal(t, dns.RcodeNameError, rec.Rcode)
 }
 
+func TestBlockedChildDomain(t *testing.T) {
+	x := Blocklist{Next: NextHandler(), domains: map[string]bool{"child.bad.domain.": true}}
+
+	b := &bytes.Buffer{}
+	golog.SetOutput(b)
+
+	ctx := context.TODO()
+	r := new(dns.Msg)
+	r.SetQuestion("bad.domain.", dns.TypeA)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	x.ServeDNS(ctx, rec, r)
+
+	assert.Equal(t, dns.RcodeSuccess, rec.Rcode)
+}
+
 func TestBlockedRoot(t *testing.T) {
 	x := Blocklist{Next: NextHandler(), domains: map[string]bool{".": true}}
 

--- a/blocklist_test.go
+++ b/blocklist_test.go
@@ -85,3 +85,20 @@ func TestBlockedParentDomain(t *testing.T) {
 
 	assert.Equal(t, dns.RcodeNameError, rec.Rcode)
 }
+
+func TestBlockedRoot(t *testing.T) {
+	x := Blocklist{Next: NextHandler(), domains: map[string]bool{".": true}}
+
+	b := &bytes.Buffer{}
+	golog.SetOutput(b)
+
+	ctx := context.TODO()
+	r := new(dns.Msg)
+	r.SetQuestion("bad.domain.", dns.TypeA)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	x.ServeDNS(ctx, rec, r)
+
+	assert.Equal(t, dns.RcodeNameError, rec.Rcode)
+}

--- a/blocklist_test.go
+++ b/blocklist_test.go
@@ -51,3 +51,20 @@ func TestBlockedDomain(t *testing.T) {
 
 	assert.Equal(t, dns.RcodeNameError, rec.Rcode)
 }
+
+func TestBlockedParentDomain(t *testing.T) {
+	x := Blocklist{Next: NextHandler(), domains: map[string]bool{"bad.domain.": true}}
+
+	b := &bytes.Buffer{}
+	golog.SetOutput(b)
+
+	ctx := context.TODO()
+	r := new(dns.Msg)
+	r.SetQuestion("child.bad.domain.", dns.TypeA)
+
+	rec := dnstest.NewRecorder(&test.ResponseWriter{})
+
+	x.ServeDNS(ctx, rec, r)
+
+	assert.Equal(t, dns.RcodeNameError, rec.Rcode)
+}


### PR DESCRIPTION
It is a fairly common practice to block top-level domains that are undesirable, and use that to block all children of that domain. This helps address cases where malware is served from generated RRs that share a common parent: you don't need to block each generated RR, only the parent domain needs blocking.