### PR TITLE
Use REFUSED instead of NXDOMAIN

### DIFF
--- a/blocklist.go
+++ b/blocklist.go
@@ -41,7 +41,7 @@ func (b Blocklist) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 
 	if b.shouldBlock(state.Name()) {
 		resp := new(dns.Msg)
-		resp.SetRcode(r, dns.RcodeNameError)
+		resp.SetRcode(r, dns.RcodeRefused)
 		err := w.WriteMsg(resp)
 
 		if err != nil {
@@ -61,7 +61,7 @@ func (b Blocklist) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Ms
 			state.RemoteAddr(),
 		)
 
-		return dns.RcodeNameError, nil
+		return dns.RcodeRefused, nil
 	}
 
 	return plugin.NextOrFailure(b.Name(), b.Next, ctx, w, r)

--- a/blocklist_test.go
+++ b/blocklist_test.go
@@ -66,7 +66,7 @@ func TestBlockedDomain(t *testing.T) {
 
 	x.ServeDNS(ctx, rec, r)
 
-	assert.Equal(t, dns.RcodeNameError, rec.Rcode)
+	assert.Equal(t, dns.RcodeRefused, rec.Rcode)
 }
 
 func TestBlockedParentDomain(t *testing.T) {
@@ -83,7 +83,7 @@ func TestBlockedParentDomain(t *testing.T) {
 
 	x.ServeDNS(ctx, rec, r)
 
-	assert.Equal(t, dns.RcodeNameError, rec.Rcode)
+	assert.Equal(t, dns.RcodeRefused, rec.Rcode)
 }
 
 func TestBlockedChildDomain(t *testing.T) {
@@ -117,5 +117,5 @@ func TestBlockedRoot(t *testing.T) {
 
 	x.ServeDNS(ctx, rec, r)
 
-	assert.Equal(t, dns.RcodeNameError, rec.Rcode)
+	assert.Equal(t, dns.RcodeRefused, rec.Rcode)
 }


### PR DESCRIPTION
It's traditional for blocklists to either replace the blocked query with an NXDOMAIN response, or to overwrite the response, removing anything provided by the upstream and adding something in TXT, HINFO, or other related record.

Although traditional, this is lying a little bit to the client: the record exists, we just don't want to serve it. We can use the CoreDNS "REFUSED" response code, which is in use by their ACL plugin, to indicate to the client that we're not going to serve this RR.